### PR TITLE
don't override project.version if already set

### DIFF
--- a/src/main/kotlin/JosmPlugin.kt
+++ b/src/main/kotlin/JosmPlugin.kt
@@ -52,7 +52,11 @@ class JosmPlugin @Inject constructor(val sourceDirectorySetFactory: SourceDirect
     project.afterEvaluate {
       if (project.extensions.josm.versionFromVcs) {
         val version = try {
-          GitDescriber(project.projectDir).describe(dirty = true)
+          val v = project.version.toString()
+          if (v == "unspecified") {
+              GitDescriber(project.projectDir).describe(dirty = true)
+          }
+          else v
         } catch (e: Exception) {
           project.logger.info("Error getting project version for ${project.projectDir} using git!", e)
           try {


### PR DESCRIPTION
If `project.version` is already set in `build.gradle`, in `gradle.properties`, or on  the command line, it should not be overriden.  Only override it if the default value is `unspecified` (see [doc](https://docs.gradle.org/current/dsl/org.gradle.api.Project.html#org.gradle.api.Project:version))