### PR TITLE
fix classpath in JosmManifest

### DIFF
--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -45,6 +45,13 @@ josm {
     // website = java.net.URL("https://example.org")
     // oldVersionDownloadLink(123, "v1.2.0", java.net.URL("https://example.org/download/v1.2.0/MyAwesomePlugin.jar"))
     // oldVersionDownloadLink( 42, "v1.0.0", java.net.URL("https://example.org/download/v1.0.0/MyAwesomePlugin.jar"))
+
+    // to populate the 'Class-Path' attribute in the JOSM plugin manifest invoke
+    // the function 'classpath', i.e.
+    //   classpath "foo.jar"
+    //   classpath "sub/dir/bar.jar"
+    // This results in 'Class-Path: foo.jar sub/dir/bar.jar' in the
+    // manifest file. Added class path entries must not contain blanks.
   }
   // i18n {
   //   bugReportEmail = "me@example.com"

--- a/plugin/src/main/kotlin/org/openstreetmap/josm/gradle/plugin/config/JosmManifest.kt
+++ b/plugin/src/main/kotlin/org/openstreetmap/josm/gradle/plugin/config/JosmManifest.kt
@@ -87,13 +87,13 @@ class JosmManifest(private val project: Project) {
    *
    * **Influenced MANIFEST.MF attribute:** [Attribute.CLASSPATH] (`Class-Path`)
    */
-  val classpath: List<String> = listOf()
+  val classpath: MutableList<String> = mutableListOf()
 
   public fun classpath(path: String) {
     require(!path.contains(' ')) {
       "A classpath must not contain space characters! If you want to add more than one, add them separately."
     }
-    (classpath as MutableList).add(path)
+    classpath.add(path)
   }
 
   /**


### PR DESCRIPTION
This fixes setting the attribute 'Class-Path' in the JOSM plugin manifest.
Example:
```
josm {
  manifest {
    classpath "foo.jar"
    classpath "bar.jar"
  }
}
```