### PR TITLE
add tests to show Manifest can't be read from build/dist/plugin.jar

### DIFF
--- a/plugin/src/main/kotlin/org/openstreetmap/josm/gradle/plugin/task/RenameArchiveFile.kt
+++ b/plugin/src/main/kotlin/org/openstreetmap/josm/gradle/plugin/task/RenameArchiveFile.kt
@@ -11,6 +11,7 @@ import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.bundling.AbstractArchiveTask
 import org.gradle.api.tasks.bundling.Zip
+import java.util.jar.JarInputStream
 import javax.inject.Inject
 
 /**
@@ -49,8 +50,11 @@ public open class RenameArchiveFile @Inject constructor(
 
   init {
     from(
-      archiverTask.map { project.zipTree(it.archiveFile).matching { it.exclude(GenerateJarManifest.MANIFEST_PATH) } },
-      manifestTask.map { project.fileTree(it.outputDirectory) { it.include(GenerateJarManifest.MANIFEST_PATH) } }
+      /* It is very important that the MANIFEST.MF file comes first!
+       * Otherwise it can't be read by a [JarInputStream]. See https://github.com/floscher/gradle-josm-plugin/pull/15
+       */
+      manifestTask.map { project.fileTree(it.outputDirectory) { it.include(GenerateJarManifest.MANIFEST_PATH) } },
+      archiverTask.map { project.zipTree(it.archiveFile).matching { it.exclude(GenerateJarManifest.MANIFEST_PATH) } }
     )
     destinationDirectory.set(targetDir)
     duplicatesStrategy = DuplicatesStrategy.FAIL

--- a/plugin/src/test/kotlin/org/openstreetmap/josm/gradle/plugin/demo/DemoTest.kt
+++ b/plugin/src/test/kotlin/org/openstreetmap/josm/gradle/plugin/demo/DemoTest.kt
@@ -4,13 +4,18 @@ import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.openstreetmap.josm.gradle.plugin.testutils.GradleProjectUtil
 import java.io.File
+import java.io.FileInputStream
 import java.security.MessageDigest
+import java.util.jar.JarFile
+import java.util.jar.JarInputStream
+import java.util.stream.Collectors
 
 class DemoTest {
 
@@ -107,6 +112,23 @@ class DemoTest {
         File(tmpDir, "build/localDist/list").exists() &&
         File(tmpDir, "build/localDist/MyAwesomePlugin-dev.jar").exists()
       }
+
+      println("Checking whether Manifest can be read from 'build/dist/MyAwesomePlugin.jar' ...")
+      // can read Manifest from build/dist/MyAwesomePlugin.jar using
+      // JarFile::getManifest().
+      //
+      // Already works.
+      val jarFile = tmpDir.resolve("build/dist/MyAwesomePlugin.jar")
+      var manifest = JarFile(jarFile).manifest
+      assertNotNull(manifest)
+
+      // can read Manifest from build/dist/MyAwesomePlugin.jar the way
+      // JOSM does it in PlugInformation using JarInputStream, see
+      // https://github.com/JOSM/josm/blob/9a72aaa8ff6264c00b1cc1186a5ac85f750ee8ad/src/org/openstreetmap/josm/plugins/PluginInformation.java#L128
+      //
+      // Doesn't work yet.
+      manifest = jarFile.inputStream().use {inputStream -> JarInputStream(inputStream).manifest}
+      assertNotNull(manifest)
     }
   }
 


### PR DESCRIPTION
* Manifest can be read using `JarFile::getManifest()`
* Manifest can't be read using `JarInputStream::getManifest()` ([the way JOSM does it][josm-code])

Possible reason: 
* MANIFEST entry is at the end of the jar file
* JarInputStream expects it at the beginning

[josm-code]: https://github.com/JOSM/josm/blob/9a72aaa8ff6264c00b1cc1186a5ac85f750ee8ad/src/org/openstreetmap/josm/plugins/PluginInformation.java#L128