### PR TITLE
Remove josm-scripting-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ Also, the [KDoc (similar to Javadoc, but for Kotlin)](https://josm.gitlab.io/gra
 * [gokaart/JOSM_**OpenQA**](https://gitlab.com/gokaart/JOSM_OpenQA)
 * [DavidKarlas/JosmRelationValidation (**Relation Validation Plugin**)](https://github.com/DavidKarlas/JosmRelationValidation)
 * [DavidKarlas/JosmReviewPlugin (**Review Changes**)](https://github.com/DavidKarlas/JosmReviewPlugin)
-* [Gubaer/josm-**scripting**-plugin](https://github.com/Gubaer/josm-scripting-plugin)
 * [JOSM/**pt_assistant**](https://gitlab.com/JOSM/plugin/pt_assistant)
 * [JOSM/**wikipedia**](https://gitlab.com/JOSM/plugin/wikipedia)
 


### PR DESCRIPTION
josm-scripting-plugin doesn't use gradle-josm-plugin anymore